### PR TITLE
feat(am-coffee-test): detect test finish

### DIFF
--- a/modules/am-coffee-time/src/Status.coffee
+++ b/modules/am-coffee-time/src/Status.coffee
@@ -15,6 +15,11 @@ module.exports = class Status
     riot.observable(@)
   @firstTimeInit: =>
     @opts = {}
+  @taskFinished: =>
+    @executeSum > 0 and @executeIframe.length === 0
+  @taskAllSuccess: =>
+    @taskFinished() and @executeSum === @successSum
+
 
 Status.init()
 Status.firstTimeInit()

--- a/modules/am-coffee-time/src/test-list.tag
+++ b/modules/am-coffee-time/src/test-list.tag
@@ -2,6 +2,8 @@ require("./test-iframe.tag")
 
 <test-list>
   <test-list-count />
+  <span if={WholeStatus.taskFinished()} class="finished">✔︎</span>
+  <span if={WholeStatus.taskAllSuccess()} class="all-success">💯</span>
   <a onclick={toRouteHash}>base</a>
   <recursive-item data={opts.testPatterns} routing="" />
   <test-iframe ref="testFrame" if={instanceUrl} url={instanceUrl} config={WholeStatus.config}></test-iframe>
@@ -20,6 +22,9 @@ require("./test-iframe.tag")
     }
     a:hover {
       opacity: 0.4;
+    }
+    .finished {
+      color: #17e017;
     }
   </style>
   <script type="coffee">


### PR DESCRIPTION
### affected modules
am-coffee-test

### description
This PR changes to put the additional dom elements in test-list component when the all test cases are finished.

After the successful test run, the page should look like the below:

<img width="428" alt="2017-02-16 15 55 29" src="https://cloud.githubusercontent.com/assets/613956/23010728/68fabba8-f460-11e6-9b36-3d1c3b8e24aa.png">

