### PR TITLE
coffee-time@browser/Testでassert失敗時にErrorを投げ、assertとerrorを区別しないように修正

### DIFF
--- a/modules/am-autoevent/browser/AutoEvent.coffee
+++ b/modules/am-autoevent/browser/AutoEvent.coffee
@@ -1,4 +1,6 @@
 $ = (selector) => document.querySelector(selector)
+assert = require("assert")
+
 trigger = ($dom, eventType) =>
   event = document.createEvent("HTMLEvents")
   event.initEvent(eventType, false, true)
@@ -21,7 +23,7 @@ module.exports = class AutoEvent
       () =>
         $this = $(selector)
         if assertionMsg
-          console.assert($this, "#{selector} #{assertionMsg}")
+          assert($this, "#{selector} #{assertionMsg}")
           callback($this)
         else
           try
@@ -76,7 +78,7 @@ module.exports = class AutoEvent
       now = Date.now()
       testTimer = setInterval( =>
         withInTimeFlg = Date.now() - now < @timeoutMsec
-        console.assert(withInTimeFlg, """timeout for "#{selector}" selector""")
+        assert(withInTimeFlg, """timeout for "#{selector}" selector""")
         return stopTimer() unless withInTimeFlg
         if exists
           if $(selector) then executeFunc()

--- a/modules/am-autoevent/package.json
+++ b/modules/am-autoevent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "am-autoevent",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "web client event",
   "main": "browser/AutoEvent-no-gen",
   "scripts": {

--- a/modules/am-autoevent/package.json
+++ b/modules/am-autoevent/package.json
@@ -8,9 +8,9 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "am-coffee-time": "0.0.25",
+    "assert": "^1.4.1",
     "jquery": "^3.1.1"
   }
 }

--- a/modules/am-autoevent/test/web/cases.yml
+++ b/modules/am-autoevent/test/web/cases.yml
@@ -3,8 +3,8 @@ am-autoevent:
     timeout=100: ./index.html
     clickAssert=true: ./index.html
     select=6: ./index.html
-  エラーじゃダメ:
     test: ./index.html
+  エラーじゃダメ:
     testNoGen: ./index.html
     timeout=5000: ./index.html
     clickAssert=false: ./index.html

--- a/modules/am-autoevent/test/web/index.coffee
+++ b/modules/am-autoevent/test/web/index.coffee
@@ -21,7 +21,6 @@ func = (Klass) =>
       console.info "finished"
     )
 
-
 require("am-coffee-time/browser/Test").start(
   test:  =>
     func(AutoEvent)
@@ -37,11 +36,10 @@ require("am-coffee-time/browser/Test").start(
     setTimeout(createTimeoutBox, 500)
   clickAssert: (assertFlg) =>
     ae = new AutoEvent
-    ae.register().wait(300).click(".box", assertFlg is "true").start()
+    ae.register().wait(300).click(".box555", assertFlg is true).start()
   select: (value) =>
     ae = new AutoEvent
     ae.register().wait(300).selectValue("select", value).start()
-    $ERROR_IS_OKAY
   scroll: =>
     scrollTest2.scrollTop = 30
     console.info "finished"

--- a/modules/am-coffee-time/browser/Test.coffee
+++ b/modules/am-coffee-time/browser/Test.coffee
@@ -2,6 +2,10 @@ $ = require("jquery")
 jquery_stylesheet = require("jquery-stylesheet")
 jquery_stylesheet($)
 
+console.assert = (args...) =>
+  result = args[0]
+  throw new Error(args[1..]) unless result
+
 getRandomColor = (opacity = 1) =>
   getRandomNum = => Math.floor(Math.random() * 256)
   "rgba(#{getRandomNum()},#{getRandomNum()},#{getRandomNum()}, #{opacity})"

--- a/modules/am-coffee-time/browser/Test.coffee
+++ b/modules/am-coffee-time/browser/Test.coffee
@@ -2,10 +2,6 @@ $ = require("jquery")
 jquery_stylesheet = require("jquery-stylesheet")
 jquery_stylesheet($)
 
-console.assert = (args...) =>
-  result = args[0]
-  throw new Error(args[1..]) unless result
-
 getRandomColor = (opacity = 1) =>
   getRandomNum = => Math.floor(Math.random() * 256)
   "rgba(#{getRandomNum()},#{getRandomNum()},#{getRandomNum()}, #{opacity})"

--- a/modules/am-coffee-time/package.json
+++ b/modules/am-coffee-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "am-coffee-time",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "test",
   "main": "browser/generate",
   "scripts": {

--- a/modules/am-coffee-time/package.json
+++ b/modules/am-coffee-time/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/ampcpmgp/amdev.git"
   },
   "dependencies": {
+    "assert": "^1.4.1",
     "am-autoevent": "^1.1.8",
     "chokidar": "^1.6.1",
     "cson": "^4.0.0",

--- a/modules/am-coffee-time/readme.md
+++ b/modules/am-coffee-time/readme.md
@@ -45,14 +45,16 @@ All passed the test by putting the console.info after it was true ("finished").
 #### sample code
 ```coffee
 Test = require("am-coffee-time/browser/Test")
+assert = require("assert")
+
 Test.start(
   click: (type) =>
     el = document.querySelector(type)
-    console.assert(el)
+    assert(el)
     el.click()
   update: ([type, value]) =>
     el = document.querySelector("input[name=#{type}]")
-    console.assert(el)
+    assert(el)
     el.value = value
 )
 

--- a/modules/am-coffee-time/src/test-iframe.tag
+++ b/modules/am-coffee-time/src/test-iframe.tag
@@ -49,12 +49,10 @@
         iframeWindow = @root.querySelector("iframe").contentWindow
         if callbackObj
           __assert = iframeWindow.console.assert
-          iframeWindow.console.assert = (args...) =>
-            __assert(args...)
-            callbackObj.assert(args[0])
-          iframeWindow.onerror = (msg) =>
-            callbackObj.error(msg)
+          iframeWindow.addEventListener("error", (event) =>
+            callbackObj.error()
             false
+          )
           __info = iframeWindow.console.info
           iframeWindow.console.info = (args...) =>
             __info(args...)

--- a/modules/am-coffee-time/src/test-list.tag
+++ b/modules/am-coffee-time/src/test-list.tag
@@ -120,7 +120,7 @@ require("./test-iframe.tag")
 <list-line>
   <section class="{line: 1,hover: isHover, last-execute: routerExecutionPath === Status.lastExecutePath}">
     <div class="" onmouseover={mouseOn} onmouseout={mouseOut}>
-      <span class="bold {success: success, error: error, warn: warn}"></span>
+      <span class="bold {success: success, error: error}"></span>
       <a class="tree" href={routing} onclick={router}>{treeName}</a>
       <label each={pattern, i in patterns} class={focus: pattern.focus} data-id={i} onclick={changePatternEvent}>
         {pattern.name}
@@ -179,12 +179,6 @@ require("./test-iframe.tag")
         content: "〇";
       }
     }
-    .warn {
-      color: gold;
-      &:after {
-        content: "△";
-      }
-    }
     .error {
       color: red;
       &:after {
@@ -240,7 +234,6 @@ require("./test-iframe.tag")
       @update()
     @init = =>
       @error = null
-      @warn = null
       @success = null
       @deleteIframe()
     @recursivelyExecuteTask = =>
@@ -270,19 +263,16 @@ require("./test-iframe.tag")
       console.clear()
       ++Status.executeSum
       @refs.testFrame.setConsoleEvent(
-        assert: (flg) =>
-          unless flg
-            @error = true
-            @update()
-            callback and callback()
         info: (msg) =>
           if msg is "finished" and not @error
-            @success = true unless @warn
+            @success = true
             ++Status.successSum
             @update()
             callback and callback()
         error: (msg) =>
-          @warn = true
+          @error = true
+          @update()
+          callback and callback()
       )
     @router = (e) =>
       route("path=" + e.target.getAttribute("href"))

--- a/modules/am-coffee-time/test/web/index.coffee
+++ b/modules/am-coffee-time/test/web/index.coffee
@@ -1,9 +1,10 @@
 $ = require("jquery")
 Parser = require("am-coffee-time/Parser")
+assert = require("assert")
 
 test =
   params1: (params1Val) =>
-    console.assert(params1Val)
+    assert(params1Val)
     setTimeout(=>
       $("body").scrollTop(100)
     , 100)
@@ -12,39 +13,39 @@ test =
     $(selector).each(->
       $this = $(this)
       tagName =$this.prop("tagName")
-      console.assert($this.css("background"), tagName)
+      assert($this.css("background"), tagName)
     )
   _border: (selector) =>
     selector = if selector is true then "*" else selector
     $(selector).each(->
       $this = $(this)
       tagName =$this.prop("tagName")
-      console.assert($this.css("border"), tagName)
+      assert($this.css("border"), tagName)
     )
   test: (num) =>
     console.log "test", num
-    console.assert(num)
+    assert(num)
   lang: (type) =>
     console.log(type)
   タスクリスト一覧: =>
     testPattern = require("./test-cases.yml")
     list = Parser.getSingleTaskList(testPattern)
     answerPattern = require("./test-cases.json")
-    console.assert(JSON.stringify(list) is JSON.stringify(answerPattern))
+    assert(JSON.stringify(list) is JSON.stringify(answerPattern))
   int: (value) =>
-    console.assert typeof value is "number"
+    assert typeof value is "number"
   bool: (value) =>
-    console.assert value is false
+    assert value is false
   types: ([key, value]) =>
-    console.assert (typeof key) is "number"
-    console.assert (typeof value) is "boolean"
+    assert (typeof key) is "number"
+    assert (typeof value) is "boolean"
   typecheck: ([string, int]) =>
-    console.assert (typeof string) is "string"
-    console.assert (typeof int) is "number"
+    assert (typeof string) is "string"
+    assert (typeof int) is "number"
   nullcheck: (data) =>
-    console.assert data is null
+    assert data is null
   undefinedCheck: (data) =>
-    console.assert data is undefined
+    assert data is undefined
 
 
 require("am-coffee-time/browser/Test").start(test)

--- a/modules/am-coffee-time/web/test.es
+++ b/modules/am-coffee-time/web/test.es
@@ -1,5 +1,7 @@
 import Test from 'am-coffee-time/browser/Test'
 import AutoEvent from 'am-autoevent/browser/AutoEvent-no-gen'
+import assert from 'assert'
+
 const autoEvent = new AutoEvent()
 const $ = (selector) => document.querySelector(selector)
 const actions = {
@@ -10,8 +12,8 @@ const actions = {
   },
   動作フロー確認用: () => console.log('動作フロー確認です'),
   結果: (値) => {
-    if (値.match('成功')) console.assert(true)
-    else if (値.match('失敗')) console.assert(false, '失敗です')
+    if (値.match('成功')) assert(true)
+    else if (値.match('失敗')) assert(false, '失敗です')
   },
   ID入力: (value) => {
     autoEvent
@@ -21,7 +23,7 @@ const actions = {
     autoEvent
       .wait(400).setValue('[name="pw"]', value)
       .wait(400).click('[name="check"]')
-      .wait(400).addEvent(() => console.assert($('after-login'), 'after-login not found'))
+      .wait(400).addEvent(() => assert($('after-login'), 'after-login not found'))
   }
 }
 autoEvent.register()

--- a/modules/am-simple-server/package.json
+++ b/modules/am-simple-server/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "assert": "^1.4.1",
     "am-common": "^1.0.31",
     "chokidar": "^1.6.1",
     "glob": "^7.1.1",

--- a/modules/am-simple-server/test/client.coffee
+++ b/modules/am-simple-server/test/client.coffee
@@ -1,3 +1,4 @@
+assert = require("assert")
 Test = require("am-coffee-time/browser/Test")
 WSClient = require("../browser/WSClient")
 
@@ -11,7 +12,7 @@ test =
       connectFlag = true
       console.info("finished")
     )
-    timeout = => console.assert(false, "websocket timeout") unless connectFlag
+    timeout = => assert(false, "websocket timeout") unless connectFlag
     setTimeout(timeout, 1500)
 
 

--- a/modules/am-streamize/package.json
+++ b/modules/am-streamize/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "assert": "^1.4.1",
     "riot": "^3.0.5",
     "riot-route": "^3.0.2"
   }

--- a/modules/am-streamize/test/app/index.coffee
+++ b/modules/am-streamize/test/app/index.coffee
@@ -1,4 +1,5 @@
 fs = require("fs")
+assert = require("assert")
 
 parser = require("am-streamize/parser")
 
@@ -8,7 +9,7 @@ require("am-coffee-time/browser/Test").start(
     json = require("./simple.json")
     result = parser(flow)
     # console.log JSON.stringify(result, null, "  ") # test用のデータ取得用
-    console.assert(JSON.stringify(result) is JSON.stringify(json), "simple flow is not same")
+    assert(JSON.stringify(result) is JSON.stringify(json), "simple flow is not same")
 )
 
 console.info("finished")

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "electron": "electron ./electron/start.js"
   },
   "dependencies": {
+    "assert": "^1.4.1",
     "babel-core": "^6.24.0",
     "babel-loader": "6",
     "babel-preset-env": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,7 +114,7 @@ assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert@^1.1.1:
+assert@^1.1.1, assert@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:


### PR DESCRIPTION
子フレーム内のasssertで、throwを投げ強制停止する作戦
https://github.com/ampcpmgp/amdev/pull/24/files#diff-417cafbdf83a9fb8e8e6c94dab865d1eR5

イベントはonerrorで拾う。
親フレームからエラーメッセージを拾えないのだけが残念。